### PR TITLE
update to goblin 0.0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ base64 = "0.5"
 bitflags = "0.9"
 capstone_rust = { git = "https://github.com/endeav0r/capstone-rust", rev="67d98f1" }
 error-chain = "0.10"
-goblin = "0.0.9"
+goblin = "0.0.11"
 lazy_static = "0.2"
 log = "0.3"
 regex = "0.2"


### PR DESCRIPTION
Does that ^ cause I broke a lot of stuff

Notes:

1. Replaced with the indexing versions for strtable (`get` was equivalent to this in 0.0.9)
2. Slightly altered the logic in loader for dynamic; i did not think about this deeply, so please correct if the logic is bad
3. Everything should be faster; the parser is zero-copy everywhere, and if you end up using the mach parser, it now actually correctly parses mach-o imports thanks to @willglynn